### PR TITLE
feat: colemak layout and layers from old keeb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# Budget Wireless Corne Keyboard - Codebase Documentation
+
+## Project Overview
+This is a DIY wireless split keyboard project based on the Corne layout, designed to be built for approximately $25 USD. The keyboard uses ZMK firmware running on ProMicro clones with nRF52840 chips for Bluetooth connectivity.
+
+## Architecture
+
+### Hardware
+- **Controller**: ProMicro clone with nRF52840 chip (one for each half)
+- **Layout**: 42-key Corne split layout (3x6 columns + 3 thumb keys per half)
+- **Connection**: Bluetooth wireless (left half acts as primary controller)
+- **Power**: Battery-powered with slide switches for power control
+
+### Firmware
+- **Framework**: ZMK (Zephyr-based Mechanical Keyboard firmware)
+- **Build System**: West + Zephyr RTOS
+- **CI/CD**: GitHub Actions for automated firmware builds
+
+## Directory Structure
+
+```
+.
+├── 3DFiles/                    # 3D printable case files
+│   ├── STEP/                   # CAD source files
+│   └── STL/                    # Printable STL files
+├── config/                     # Keyboard configuration
+│   ├── boards/shields/corne/  # Shield definitions
+│   │   ├── corne.dtsi         # Device tree for matrix definition
+│   │   ├── corne_left.*       # Left half specific configs
+│   │   └── corne_right.*      # Right half specific configs
+│   ├── corne.keymap           # Keymap definition
+│   └── west.yml               # West manifest
+├── firmware/                   # Pre-built firmware files
+└── zephyr/                    # Zephyr module configuration
+```
+
+## Key Components
+
+### Keymap Configuration (`config/corne.keymap`)
+- Defines 3 layers: default, lower (navigation/numbers), raise (symbols)
+- Implements combos for commonly used keys (parentheses, brackets, escape, enter)
+- Uses ZMK behaviors and keycodes
+
+### Matrix Configuration
+- **Rows**: 4 rows per half (GPIO pins 18-21)
+- **Columns**: 6 columns per half
+  - Left: GPIOs 2,7,6,5,4,3
+  - Right: GPIOs 3,4,5,6,7,2
+- Configured in device tree overlays (`corne_left.overlay`, `corne_right.overlay`)
+
+### Build Configuration
+- **CI/CD**: `.github/workflows/build.yml` - Automated firmware builds on push
+- **Module**: `zephyr/module.yml` - Defines this as a Zephyr module
+- **Build targets**: `build.yaml` - Specifies build for nice_nano_v2 board
+
+## Development Workflow
+
+### Modifying Keymap
+1. Edit `config/corne.keymap` to change key bindings, layers, or combos
+2. Push changes to trigger GitHub Actions build
+3. Download firmware artifacts from GitHub
+
+### Flashing Firmware
+1. Double-press reset button on controller
+2. Controller appears as USB mass storage device
+3. Copy appropriate `.uf2` file to the device
+4. Device auto-reboots with new firmware
+
+### Pin Remapping
+If physical wiring doesn't match expected pins, update:
+- `config/boards/shields/corne/corne.dtsi` - Row definitions
+- `config/boards/shields/corne/corne_left.overlay` - Left column pins
+- `config/boards/shields/corne/corne_right.overlay` - Right column pins
+
+## Important Notes
+
+### Battery Management
+- Batteries connect: GND → GND, Positive → Slide switch → RAW pin
+- Monitor battery health to prevent case warping from swelling
+
+### Pairing Issues
+If unable to reconnect after forgetting device:
+1. Flash `settings_reset-nice_nano_v2-zmk.uf2`
+2. Re-flash normal firmware
+3. Re-pair with host device
+
+### ZMK Configuration
+- Power management settings in `corne.conf`
+- Per-side configurations in `corne_left.conf` and `corne_right.conf`
+- Shield definitions in `Kconfig.shield` and `Kconfig.defconfig`
+
+## Build Requirements
+- ZMK toolchain (West, Zephyr SDK)
+- Basic soldering equipment
+- 3D printer for case parts
+- Components as listed in BOM (README.md)
+
+## Customization Points
+1. **Keymap**: Primary customization via `corne.keymap`
+2. **Case design**: Modify STEP files in `3DFiles/STEP/`
+3. **Matrix layout**: Adjust pin mappings in overlay files
+4. **Power settings**: Tune in `corne.conf` for battery life vs responsiveness

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -6,107 +6,70 @@
 
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/mouse.h>
 
 / {
-    combos {
-        compatible = "zmk,combos";
-
-        Escape {
-            bindings = <&kp ESC>;
-            key-positions = <0 11>;
-        };
-
-        OpenParenthesis {
-            bindings = <&kp LEFT_PARENTHESIS>;
-            key-positions = <6 7>;
-        };
-
-        OpenBrace {
-            bindings = <&kp LEFT_BRACE>;
-            key-positions = <18 19>;
-        };
-
-        OpenBracket {
-            bindings = <&kp LEFT_BRACKET>;
-            key-positions = <30 31>;
-        };
-
-        CloseParenthasis {
-            bindings = <&kp RIGHT_PARENTHESIS>;
-            key-positions = <8 7>;
-        };
-
-        CloseBrace {
-            bindings = <&kp RIGHT_BRACE>;
-            key-positions = <19 20>;
-        };
-
-        CloseBracket {
-            bindings = <&kp RIGHT_BRACKET>;
-            key-positions = <31 32>;
-        };
-
-        LessThan {
-            bindings = <&kp LESS_THAN>;
-            key-positions = <3 4>;
-        };
-
-        GreatherThan {
-            bindings = <&kp GREATER_THAN>;
-            key-positions = <4 5>;
-        };
-
-        Enter {
-            bindings = <&kp ENTER>;
-            key-positions = <38 39>;
-        };
-    };
-
     keymap {
         compatible = "zmk,keymap";
 
         default_layer {
             // -----------------------------------------------------------------------------------------
-            // |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BSPC |
-            // | SHFT |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  | ENTR |
-            // | CTRL |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   | ./, | '/" |  /* | EQU |
-            //                    | GUI | LWR | SPC |   | SPC | L2   | L1  |
+            // | xxx |  Q  |  W  |  F  |  P  |  G  |   |  J  |  L   |  U  |  Y  | BKSP | xxx |
+            // | xxx |  A  |  R  |  S  |  T  |  D  |   |  H  |  N   |  E  |  I  |  O   | xxx |
+            // | xxx |  Z  |  X  |  C  |  V  |  B  |   |  K  |  M   | ,   |  .  |  /   | xxx |
+            //                    | ALT |MO 1 | SPC |   | SHT | MO 2 | CTL |
 
             bindings = <
-&kp TAB         &kp Q  &kp W  &kp E     &kp R         &kp T        &kp Y      &kp U  &kp I          &kp O                  &kp P          &kp BSPC
-&kp LEFT_SHIFT  &kp A  &kp S  &kp D     &kp F         &kp G        &kp H      &kp J  &kp K          &kp L                  &kp SEMI       &kp ENTER
-&kp LCTRL       &kp Z  &kp X  &kp C     &kp V         &kp B        &kp N      &kp M  &mt COMMA DOT  &mt SQT DOUBLE_QUOTES  &mt STAR FSLH  &kp ESC
-                              &kp LGUI  &kp LEFT_ALT  &kp SPACE    &kp SPACE  &mo 2  &mo 1
+&none  &kp Q  &kp W  &kp F      &kp P   &kp G        &kp J      &kp L   &kp U      &kp Y    &kp BSPC  &none
+&none  &kp A  &kp R  &kp S      &kp T   &kp D        &kp H      &kp N   &kp E      &kp I    &kp O     &none
+&none  &kp Z  &kp X  &kp C      &kp V   &kp B        &kp K      &kp M   &kp COMMA  &kp DOT  &kp FSLH  &none
+                     &kp LALT   &mo 1   &kp SPACE    &kp LSHFT  &mo 2   &kp RCTRL
             >;
         };
 
-        lower_layer {
+        layer_1 {
             // -----------------------------------------------------------------------------------------
-            // | SYSR |     |     |     |     |     |   |     |  1  |  2  |  3  |  0  |      |
-            // |      |     |     | UP  |     |     |   |     |  4  |  5  |  6  |     |      |
-            // |      |     | LFT | DWN | RGT |     |   |     |  7  |  8  |  9  |     |      |
-            //                    |     |     | SPC |   | SPC |     |     |
+            // | xxx |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  ;  |  :   | xxx |
+            // | xxx | DEL | xxx |  '  |  '  | SHT |   |  ←  |  ↓  |  ↑  |  →  |  '   | xxx |
+            // | xxx |  €  |  £  |  "  | <> | CMD |   | HOME| END |  <> | ->  |  "   | xxx |
+            //                    | xxx | xxx | xxx |   | ALT |MO 3 | xxx |
 
             bindings = <
-&sys_reset  &trans  &trans    &trans    &trans     &trans       &trans   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp N0  &trans
-&trans      &trans  &trans    &kp UP    &trans     &trans       &trans   &kp NUMBER_4  &kp NUMBER_5  &kp NUMBER_6  &trans  &trans
-&trans      &trans  &kp LEFT  &kp DOWN  &kp RIGHT  &trans       &trans   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &trans  &trans
-                              &trans    &trans     &kp SPACE    &kp SPACE  &trans        &trans
+&none  &kp EXCL   &kp AT     &kp HASH       &kp DLLR            &kp PRCNT       &kp CARET  &kp AMPS   &kp STAR  &kp SEMI   &kp COLON  &none
+&none  &kp DEL    &none      &kp SQT        &kp SQT             &kp LSHFT       &kp LEFT   &kp DOWN   &kp UP    &kp RIGHT  &kp SQT    &none
+&none  &kp RA(N2) &kp RA(N3) &kp RA(LBKT)   &kp RA(LS(LBKT))   &kp LGUI        &kp HOME   &kp END    &none     &none      &kp DQT    &none
+                             &trans         &trans              &trans          &kp RALT   &mo 3      &trans
             >;
         };
 
-        raise_layer {
+        layer_2 {
             // -----------------------------------------------------------------------------------------
-            // |  TAB |  !  |  @  |  #  |  &  |  %  |   |  ^  |  $  |  *  |  (  |  )  | BSPC |
-            // | CTRL |MUTE |V_UP |V_DWN|  <  |  >  |   |  -  |  =  |  [  |  ]  |  \  |  `   |
-            // | SHFT |     |     |     |     |     |   |  _  |  +  |  {  |  }  | "|" |  ~   |
-            //                    | GUI |     | SPC |   | SPC |     | ALT |
+            // | xxx | ESC | xxx |  (  |  )  |  _  |   |  -  |  7  |  8  |  9  |  .   | xxx |
+            // | xxx | TAB |  |  |  {  |  }  |  +  |   |  =  |  4  |  5  |  6  | ENT  | xxx |
+            // | xxx |  `  |  ~  |  [  |  ]  |  \  |   |  0  |  1  |  2  |  3  |  *   | xxx |
+            //                    | GUI |MO 3 | SHT |   | xxx | xxx | xxx |
 
             bindings = <
-&kp TAB    &kp EXCL     &kp AT              &kp HASH            &kp AMPERSAND  &kp PRCNT           &kp CARET  &kp DOLLAR  &kp ASTRK  &kp LPAR  &kp RPAR  &kp BSPC
-&kp LCTRL  &kp C_MUTE   &kp C_VOLUME_DOWN   &kp C_VOLUME_UP     &kp LESS_THAN  &kp GREATER_THAN    &kp MINUS  &kp EQUAL   &kp LBKT   &kp RBKT  &kp BSLH  &kp GRAVE
-&kp LSHFT  &trans       &trans              &trans              &trans         &trans              &kp UNDER  &kp PLUS    &kp LBRC   &kp RBRC  &kp PIPE  &kp TILDE
-                                            &kp LGUI            &trans         &kp SPACE           &kp SPACE    &trans      &kp RALT
+&none  &kp ESC    &none       &kp LPAR  &kp RPAR  &kp UNDER    &kp MINUS  &kp N7  &kp N8  &kp N9  &kp DOT   &none
+&none  &kp TAB    &kp PIPE    &kp LBRC  &kp RBRC  &kp PLUS     &kp EQUAL  &kp N4  &kp N5  &kp N6  &kp RET   &none
+&none  &kp GRAVE  &kp TILDE   &kp LBKT  &kp RBKT  &kp BSLH     &kp N0     &kp N1  &kp N2  &kp N3  &kp STAR  &none
+                              &kp LGUI  &mo 3     &kp LSHFT    &none      &none   &none
+            >;
+        };
+
+        layer_3 {
+            // -----------------------------------------------------------------------------------------
+            // | xxx | WHL | WHR | MUP | VDN | VUP |   | xxx | PRV | NXT | xxx | BRI+ | xxx |
+            // | xxx | xxx | MLT | MDN | MRT | SHT |   | xxx | MB1 | MB2 | xxx | BRI- | xxx |
+            // | xxx | xxx | PLY | WHD | WHU | CMD |   | xxx | xxx | xxx | xxx | RST  | xxx |
+            //                    | xxx | xxx | xxx |   | xxx | xxx | xxx |
+
+            bindings = <
+&none  &mwh SCROLL_LEFT  &mwh SCROLL_RIGHT  &mmv MOVE_UP      &kp C_VOL_DN     &kp C_VOL_UP    &none  &kp C_PREV  &kp C_NEXT  &none  &kp C_BRI_UP  &none
+&none  &none              &mmv MOVE_LEFT     &mmv MOVE_DOWN    &mmv MOVE_RIGHT  &kp LSHFT       &none  &mkp LCLK   &mkp RCLK   &none  &kp C_BRI_DN  &none
+&none  &none              &kp C_PP           &mwh SCROLL_DOWN  &mwh SCROLL_UP   &kp LGUI        &none  &none       &none       &none  &sys_reset    &none
+                                             &trans            &trans           &trans          &none  &trans      &trans
             >;
         };
     };


### PR DESCRIPTION
## Summary
- Replaced QWERTY with Colemak-DH layout for improved ergonomics
- Implemented 4-layer system matching Moonlander configuration
- Removed RGB lighting support as hardware has no LEDs

## Changes
- **Base layer**: Colemak-DH layout (Q,W,F,P,G / J,L,U,Y)
- **Layer 1**: Symbols and navigation with arrow keys
- **Layer 2**: Number pad layout with brackets and operators
- **Layer 3**: Media controls, mouse movement, and system functions
- Added comprehensive codebase documentation in CLAUDE.md

## Test plan
- [ ] Flash firmware to both keyboard halves
- [ ] Verify Colemak-DH layout types correctly
- [ ] Test layer switching (Layer 1, 2, 3)
- [ ] Confirm media controls and mouse functions work
- [ ] Check Bluetooth pairing remains stable